### PR TITLE
Load Script strings from binary (Unity TextAsset)

### DIFF
--- a/VGPrompter/Script/Script.TextManager.cs
+++ b/VGPrompter/Script/Script.TextManager.cs
@@ -152,13 +152,21 @@ namespace VGPrompter {
                 File.WriteAllText(path, sb.ToString());
             }
 
-            public void FromCSV(string path) {
+            public void FromCSV(string path)
+            {
+                var rows = File.ReadAllLines(path);
+                FromCSV(rows);
+            }
 
+            public void FromCSV(string[] rows)
+            {
                 _dialogue_strings.Clear();
                 _global_strings.Clear();
 
                 var tokens = new string[3];
-                foreach (var row in File.ReadAllLines(path)) {
+                foreach (var row in rows) {
+                    
+                    if (string.IsNullOrEmpty(row)) continue;
 
                     tokens = row.Split(SEPARATOR, 3);
                     var label = tokens[0];
@@ -175,9 +183,8 @@ namespace VGPrompter {
                     }
 
                 }
-
+                
             }
-
         }
 
     }

--- a/VGPrompter/Script/Script.cs
+++ b/VGPrompter/Script/Script.cs
@@ -174,6 +174,14 @@ namespace VGPrompter {
             return Utils.FromBinary<Script>(bytes);
         }
 
+        public static Script FromBinary(byte[] script_bytes, byte[] strings_bytes)
+        {
+            var script = FromBinary(script_bytes);
+            var rows = System.Text.Encoding.UTF8.GetString(strings_bytes);
+            script.LoadStrings(rows);
+            return script;
+        }
+
         public static Script FromFiles(string script_path, string strings_path) {
             var script = FromBinary(script_path);
             script.LoadStrings(strings_path);
@@ -338,6 +346,13 @@ namespace VGPrompter {
                 _text_manager = new TextManager();
 
             _text_manager.FromCSV(path);
+        }
+
+        public void LoadStrings(string[] rows) {
+            if (_text_manager == null)
+                _text_manager = new TextManager();
+
+            _text_manager.FromCSV(rows);
         }
 
         public void ToFile(string path) {

--- a/VGPrompter/Script/Script.cs
+++ b/VGPrompter/Script/Script.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections;
+using System.Text.RegularExpressions;
 
 namespace VGPrompter {
 
@@ -177,7 +178,7 @@ namespace VGPrompter {
         public static Script FromBinary(byte[] script_bytes, byte[] strings_bytes)
         {
             var script = FromBinary(script_bytes);
-            var rows = System.Text.Encoding.UTF8.GetString(strings_bytes);
+            var rows = Regex.Split(System.Text.Encoding.UTF8.GetString(strings_bytes), Environment.NewLine);
             script.LoadStrings(rows);
             return script;
         }


### PR DESCRIPTION
On mobile file system with Unity, it's hard to access file via path.
What I do was reading script and strings files and re-write to other path which Unity can access on mobile.

I want to directly assign binaries(as TextAsset) in Inspector.

Loading script from bytes is already supported.
So I add tiny function to load strings from binary.